### PR TITLE
fix: days interval check

### DIFF
--- a/Abfallkalender/module.php
+++ b/Abfallkalender/module.php
@@ -283,7 +283,7 @@
                 
                 $HTMLBox.= "<tr><td>" . $key . ":</td>";
                 $interval = $value->diff($today);
-                $days = $interval->format('%d');
+                $days = $interval->format('%a');
                 If ($days == 1)
                 {
                     $ColorHEX = dechex($this->ReadPropertyInteger("selColHtmlPickupDayTomorrow"));


### PR DESCRIPTION
%d nimmt nur den Tag des Monats, was zu einem falschen Ergebnis kommen kann, wenn der nächste Termin erst im nächsten Monat ist (z.B. am 01.02.2024 würde ein Abholtermin 01.03.2024 als "heute" angezeigt werden). Stattdessen sollte %a verwendet werden, um auch eventuelle Unterschiede in Monat und Jahr zu berücksichtigen.